### PR TITLE
Add properties for image dimensions

### DIFF
--- a/EPPlus/Drawing/ExcelPicture.cs
+++ b/EPPlus/Drawing/ExcelPicture.cs
@@ -38,8 +38,10 @@ using System.IO;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Diagnostics;
+using System.Windows;
 using OfficeOpenXml.Utils;
 using OfficeOpenXml.Compatibility;
+using Size = System.Drawing.Size;
 
 namespace OfficeOpenXml.Drawing
 {
@@ -353,6 +355,16 @@ namespace OfficeOpenXml.Drawing
             get;
             set;
         }
+
+        public Vector GetOffset()
+        {
+            return new Vector(_left, _top);
+        }
+        public Size GetSize()
+        {
+            return new Size(_width, _height);
+        }
+
         /// <summary>
         /// Set the size of the image in percent from the orginal size
         /// Note that resizing columns / rows after using this function will effect the size of the picture

--- a/EPPlus/ExcelWorksheet.cs
+++ b/EPPlus/ExcelWorksheet.cs
@@ -406,6 +406,7 @@ namespace OfficeOpenXml
             _flags = new FlagCellStore();
             _commentsStore = new CellStore<int>();
             _hyperLinks = new CellStore<Uri>();
+            _mergedCells = new MergeCellsCollection();
 
             _names = new ExcelNamedRangeCollection(Workbook, this);
 
@@ -1111,6 +1112,27 @@ namespace OfficeOpenXml
             }
             return (Utils.ConvertUtil._invariantCompareInfo.IsSuffix(xr.LocalName, tagName[0]));
         }
+        private bool ReadUntil(XmlReader xr, int desiredDepth, params string[] tagName)
+        {
+            if (xr.EOF) return false;
+            while (!Array.Exists(tagName, tag => Utils.ConvertUtil._invariantCompareInfo.IsSuffix(xr.LocalName, tag)))
+            {
+                if (xr.Depth == desiredDepth)
+                {
+                    xr.Read();
+                    if (xr.EOF) return false;
+                }
+                else
+                {
+                    while (xr.Depth != desiredDepth)
+                    {
+                        xr.Read();
+                        if (xr.EOF) return false;
+                    }
+                }
+            }
+            return (Utils.ConvertUtil._invariantCompareInfo.IsSuffix(xr.LocalName, tagName[0]));
+        }
         private void LoadColumns(XmlReader xr)//(string xml)
         {
             var colList = new List<IRangeID>();
@@ -1427,7 +1449,7 @@ namespace OfficeOpenXml
         /// <param name="xr"></param>
         private void LoadMergeCells(XmlReader xr)
         {
-            if (ReadUntil(xr, "mergeCells", "hyperlinks", "rowBreaks", "colBreaks") && !xr.EOF)
+            if (ReadUntil(xr, 1, "mergeCells", "hyperlinks", "rowBreaks", "colBreaks") && !xr.EOF)
             {
                 while (xr.Read())
                 {


### PR DESCRIPTION
Properties for a resized image's dimensions were not publicly available.

Override the ReadUntil method to include depth: While reading a sheet, the mergedCells property isn't always loaded due to tags matching the incoming tag array. Matching with depth resolves this.
